### PR TITLE
Add JDK version as an action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,11 @@ inputs:
     required: false
     default: '9200'
 
+  jdk-version:
+    description: 'The version of the JDK that should be used, e.g "21"'
+    required: false
+    default: '11'
+
 runs:
   using: "composite"
   steps:
@@ -40,7 +45,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: ${{ inputs.jdk-version }}
 
     # Download OpenSearch
     - name: Download OpenSearch for Windows


### PR DESCRIPTION
### Description
Add JDK version as an action input

### Issues Resolved
Comes from https://github.com/opensearch-project/security/issues/4407 where the baseline JDK becomes 21.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
