### PR TITLE
Make startup sleep time configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ inputs:
     required: false
     default: 'false'
 
+  startup-sleep-seconds:
+    description: 'Seconds to wait for OpenSearch to start before running health checks'
+    required: false
+    default: '30'
+
 runs:
   using: "composite"
   steps:
@@ -194,7 +199,7 @@ runs:
     - name: Sleep while OpenSearch starts
       uses: peternied/action-sleep@v1
       with:
-        seconds: 30
+        seconds: ${{ inputs.startup-sleep-seconds }}
 
      # Verify that the server is operational
     - name: Check OpenSearch Running on Linux


### PR DESCRIPTION
### Description

Make startup sleep time configurable

### Issues Resolved

Trying to resolve flakiness in Windows startup which takes longer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
