### PR TITLE
Change default wait from 30s to 45s

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
   startup-sleep-seconds:
     description: 'Seconds to wait for OpenSearch to start before running health checks'
     required: false
-    default: '30'
+    default: '45'
 
 runs:
   using: "composite"


### PR DESCRIPTION
### Description

Change default wait from 30s to 45s to allow Windows more time to boot up

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
